### PR TITLE
Implement Kafka events on order actions

### DIFF
--- a/Domain/IOrderRepository.cs
+++ b/Domain/IOrderRepository.cs
@@ -1,0 +1,7 @@
+namespace dotnet_microservices_boilerplate.Domain;
+
+public interface IOrderRepository
+{
+    Task SaveAsync(Order order);
+    Task<Order?> GetAsync(Guid id);
+}

--- a/Domain/KafkaProducer.cs
+++ b/Domain/KafkaProducer.cs
@@ -1,0 +1,21 @@
+using Confluent.Kafka;
+
+namespace dotnet_microservices_boilerplate.Domain;
+
+public class KafkaProducer
+{
+    private readonly IProducer<Null, string> _producer;
+    private readonly string _topic;
+
+    public KafkaProducer(string bootstrapServers, string topic)
+    {
+        var config = new ProducerConfig { BootstrapServers = bootstrapServers };
+        _producer = new ProducerBuilder<Null, string>(config).Build();
+        _topic = topic;
+    }
+
+    public async Task PublishAsync(string message)
+    {
+        await _producer.ProduceAsync(_topic, new Message<Null, string> { Value = message });
+    }
+}

--- a/Domain/Order.cs
+++ b/Domain/Order.cs
@@ -1,0 +1,8 @@
+namespace dotnet_microservices_boilerplate.Domain;
+
+public class Order
+{
+    public Guid Id { get; init; }
+    public DateTime CreatedAt { get; init; }
+    public IList<string> Items { get; init; } = new List<string>();
+}

--- a/Domain/OrderService.cs
+++ b/Domain/OrderService.cs
@@ -1,0 +1,30 @@
+using System.Text.Json;
+
+namespace dotnet_microservices_boilerplate.Domain;
+
+public class OrderService
+{
+    private readonly IOrderRepository _repository;
+    private readonly KafkaProducer _producer;
+
+    public OrderService(IOrderRepository repository, KafkaProducer producer)
+    {
+        _repository = repository;
+        _producer = producer;
+    }
+
+    public async Task CreateOrderAsync(Order order)
+    {
+        await _repository.SaveAsync(order);
+        var message = JsonSerializer.Serialize(new { Event = "OrderCreated", OrderId = order.Id, Timestamp = DateTime.UtcNow });
+        await _producer.PublishAsync(message);
+    }
+
+    public async Task<Order?> GetOrderAsync(Guid id)
+    {
+        var order = await _repository.GetAsync(id);
+        var message = JsonSerializer.Serialize(new { Event = "OrderFetched", OrderId = id, Timestamp = DateTime.UtcNow });
+        await _producer.PublishAsync(message);
+        return order;
+    }
+}

--- a/dotnet-microservices-boilerplate.csproj
+++ b/dotnet-microservices-boilerplate.csproj
@@ -6,6 +6,10 @@
     <RootNamespace>dotnet_microservices_boilerplate</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-  </PropertyGroup>
+</PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Confluent.Kafka" Version="2.1.0" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add Order domain objects and repository interface
- implement `KafkaProducer` to publish messages
- create `OrderService` to send Kafka events on order creation and retrieval
- reference Confluent.Kafka package

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687af0f1aa508323bbd4674c58c792a5