### PR TITLE
Implement KafkaBroker in Domain layer

### DIFF
--- a/OrderService/Domain/Brokers/KafkaBroker.cs
+++ b/OrderService/Domain/Brokers/KafkaBroker.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using Confluent.Kafka;
+
+namespace dotnet_microservices_boilerplate.OrderService.Domain.Brokers;
+
+/// <summary>
+/// Simple Kafka producer used by the domain to publish events.
+/// </summary>
+public interface IKafkaBroker
+{
+    /// <summary>
+    /// Sends the specified message to the given Kafka topic.
+    /// </summary>
+    Task ProduceAsync<T>(string topic, T message, CancellationToken cancellationToken = default);
+}
+
+public sealed class KafkaBroker : IKafkaBroker, IDisposable
+{
+    private readonly IProducer<Null, string> _producer;
+
+    public KafkaBroker(string bootstrapServers)
+    {
+        var config = new ProducerConfig { BootstrapServers = bootstrapServers };
+        _producer = new ProducerBuilder<Null, string>(config).Build();
+    }
+
+    public async Task ProduceAsync<T>(string topic, T message, CancellationToken cancellationToken = default)
+    {
+        var payload = JsonSerializer.Serialize(message);
+        await _producer.ProduceAsync(topic, new Message<Null, string> { Value = payload }, cancellationToken);
+    }
+
+    public void Dispose() => _producer.Dispose();
+}

--- a/dotnet-microservices-boilerplate.csproj
+++ b/dotnet-microservices-boilerplate.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="MediatR" Version="13.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />
+    <PackageReference Include="Confluent.Kafka" Version="2.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add KafkaBroker service in Domain layer for publishing events to Kafka
- reference Confluent.Kafka in the project

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687af2f7f880832392f4193c2c29c621