### PR TITLE
Switch OrderRepository to Postgres

### DIFF
--- a/OrderService/Infrastructure/Data/OrderDbContext.cs
+++ b/OrderService/Infrastructure/Data/OrderDbContext.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+using dotnet_microservices_boilerplate.OrderService.Domain.Entities;
+
+namespace dotnet_microservices_boilerplate.OrderService.Infrastructure.Data;
+
+public sealed class OrderDbContext : DbContext
+{
+    public OrderDbContext(DbContextOptions<OrderDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Order> Orders => Set<Order>();
+    public DbSet<OrderItem> OrderItems => Set<OrderItem>();
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        base.OnModelCreating(builder);
+
+        builder.Entity<Order>(entity =>
+        {
+            entity.ToTable("orders");
+            entity.HasKey(o => o.Id);
+            entity.Property(o => o.Status).IsRequired();
+            entity.HasMany(o => o.Items)
+                  .WithOne()
+                  .HasForeignKey("OrderId")
+                  .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        builder.Entity<OrderItem>(entity =>
+        {
+            entity.ToTable("order_items");
+            entity.HasKey(i => i.Id);
+            entity.Property<Guid>("OrderId");
+            entity.Property(i => i.ProductName);
+            entity.Property(i => i.Quantity);
+            entity.Property(i => i.UnitPrice);
+        });
+    }
+}

--- a/OrderService/Infrastructure/Data/OrderRepository.cs
+++ b/OrderService/Infrastructure/Data/OrderRepository.cs
@@ -1,20 +1,44 @@
+using Microsoft.EntityFrameworkCore;
 using dotnet_microservices_boilerplate.OrderService.Domain.Entities;
 
 namespace dotnet_microservices_boilerplate.OrderService.Infrastructure.Data;
 
 public sealed class OrderRepository
 {
-    private static readonly Dictionary<Guid, Order> _store = new();
+    private readonly OrderDbContext _dbContext;
 
-    public Task SaveAsync(Order order, CancellationToken cancellationToken = default)
+    public OrderRepository(OrderDbContext dbContext)
     {
-        _store[order.Id] = order;
-        return Task.CompletedTask;
+        _dbContext = dbContext;
     }
 
-    public Task<Order?> GetAsync(Guid id, CancellationToken cancellationToken = default)
+    public async Task SaveAsync(Order order, CancellationToken cancellationToken = default)
     {
-        _store.TryGetValue(id, out var order);
-        return Task.FromResult(order);
+        var existing = await _dbContext.Orders
+            .Include(o => o.Items)
+            .FirstOrDefaultAsync(o => o.Id == order.Id, cancellationToken);
+
+        if (existing is null)
+        {
+            await _dbContext.Orders.AddAsync(order, cancellationToken);
+        }
+        else
+        {
+            _dbContext.Entry(existing).CurrentValues.SetValues(order);
+            existing.Items.Clear();
+            foreach (var item in order.Items)
+            {
+                existing.Items.Add(item);
+            }
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<Order?> GetAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.Orders
+            .Include(o => o.Items)
+            .FirstOrDefaultAsync(o => o.Id == id, cancellationToken);
     }
 }

--- a/OrderService/Infrastructure/Data/create_tables.sql
+++ b/OrderService/Infrastructure/Data/create_tables.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS orders (
+    id UUID PRIMARY KEY,
+    status TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS order_items (
+    id UUID PRIMARY KEY,
+    order_id UUID NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+    product_name TEXT NULL,
+    quantity INTEGER NOT NULL,
+    unit_price NUMERIC(18,2) NOT NULL
+);

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,8 @@
 var builder = WebApplication.CreateBuilder(args);
 
 using dotnet_microservices_boilerplate.OrderService.Domain.Brokers;
+using dotnet_microservices_boilerplate.OrderService.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
 
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
@@ -11,6 +13,12 @@ builder.Services.AddMediatR(cfg =>
 
 var kafkaBootstrap = builder.Configuration.GetValue<string>("Kafka:BootstrapServers") ?? "localhost:9092";
 builder.Services.AddSingleton<IKafkaBroker>(_ => new KafkaBroker(kafkaBootstrap));
+
+var connectionString = builder.Configuration.GetConnectionString("Orders") ??
+                       "Host=localhost;Database=orders_db;Username=postgres;Password=postgres";
+builder.Services.AddDbContext<OrderDbContext>(options =>
+    options.UseNpgsql(connectionString));
+builder.Services.AddScoped<OrderRepository>();
 
 var app = builder.Build();
 

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -5,6 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "ConnectionStrings": {
+    "Orders": "Host=localhost;Database=orders_db;Username=postgres;Password=postgres"
+  },
   "Kafka": {
     "BootstrapServers": "localhost:9092"
   }

--- a/appsettings.json
+++ b/appsettings.json
@@ -7,6 +7,9 @@
   },
   "AllowedHosts": "*"
   ,
+  "ConnectionStrings": {
+    "Orders": "Host=localhost;Database=orders_db;Username=postgres;Password=postgres"
+  },
   "Kafka": {
     "BootstrapServers": "localhost:9092"
   }

--- a/dotnet-microservices-boilerplate.csproj
+++ b/dotnet-microservices-boilerplate.csproj
@@ -10,6 +10,8 @@
     <PackageReference Include="MediatR" Version="13.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />
     <PackageReference Include="Confluent.Kafka" Version="2.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add EF Core and Npgsql packages
- implement `OrderDbContext` for Postgres persistence
- refactor `OrderRepository` to use EF Core context
- configure DbContext and repository in `Program.cs`
- store Postgres connection string in appsettings
- provide SQL script to create tables

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ba2e18ec88323893aebd70a92a28b