### PR TITLE
Add Redis caching layer

### DIFF
--- a/OrderService/Application/Handlers/GetOrderByIdHandler.cs
+++ b/OrderService/Application/Handlers/GetOrderByIdHandler.cs
@@ -1,0 +1,28 @@
+using MediatR;
+using dotnet_microservices_boilerplate.OrderService.Application.Dtos;
+using dotnet_microservices_boilerplate.OrderService.Application.Queries;
+using dotnet_microservices_boilerplate.OrderService.Infrastructure.ViewData;
+
+namespace dotnet_microservices_boilerplate.OrderService.Application.Handlers;
+
+public sealed class GetOrderByIdHandler : IRequestHandler<GetOrderByIdQuery, OrderDto>
+{
+    private readonly OrderViewRepository _repository;
+
+    public GetOrderByIdHandler(OrderViewRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<OrderDto> Handle(GetOrderByIdQuery request, CancellationToken cancellationToken)
+    {
+        var order = await _repository.GetByIdAsync(request.Id, cancellationToken);
+        if (order is null)
+        {
+            throw new KeyNotFoundException($"Order {request.Id} not found");
+        }
+
+        var items = order.Items.Select(i => new OrderItemDto(i.Id, i.ProductName ?? string.Empty, i.Quantity, i.UnitPrice)).ToList();
+        return new OrderDto(order.Id, order.Status, items);
+    }
+}

--- a/OrderService/Application/Handlers/ListOrdersHandler.cs
+++ b/OrderService/Application/Handlers/ListOrdersHandler.cs
@@ -1,0 +1,30 @@
+using MediatR;
+using dotnet_microservices_boilerplate.OrderService.Application.Dtos;
+using dotnet_microservices_boilerplate.OrderService.Application.Queries;
+using dotnet_microservices_boilerplate.OrderService.Infrastructure.ViewData;
+
+namespace dotnet_microservices_boilerplate.OrderService.Application.Handlers;
+
+public sealed class ListOrdersHandler : IRequestHandler<ListOrdersQuery, PagedResult<OrderDto>>
+{
+    private readonly OrderViewRepository _repository;
+
+    public ListOrdersHandler(OrderViewRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<PagedResult<OrderDto>> Handle(ListOrdersQuery request, CancellationToken cancellationToken)
+    {
+        var page = request.Page < 1 ? 1 : request.Page;
+        var orders = await _repository.ListAsync(request.Status, page, request.PageSize, cancellationToken);
+
+        var items = orders.Select(o => new OrderDto(
+            o.Id,
+            o.Status,
+            o.Items.Select(i => new OrderItemDto(i.Id, i.ProductName ?? string.Empty, i.Quantity, i.UnitPrice)).ToList()
+        )).ToList();
+
+        return new PagedResult<OrderDto>(items, page, request.PageSize, items.Count);
+    }
+}

--- a/OrderService/Infrastructure/ViewData/OrderViewRepository.cs
+++ b/OrderService/Infrastructure/ViewData/OrderViewRepository.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
+using dotnet_microservices_boilerplate.OrderService.Domain.Entities;
+using dotnet_microservices_boilerplate.OrderService.Infrastructure.Data;
+
+namespace dotnet_microservices_boilerplate.OrderService.Infrastructure.ViewData;
+
+public sealed class OrderViewRepository
+{
+    private readonly OrderDbContext _dbContext;
+    private readonly IDistributedCache _cache;
+
+    public OrderViewRepository(OrderDbContext dbContext, IDistributedCache cache)
+    {
+        _dbContext = dbContext;
+        _cache = cache;
+    }
+
+    private static string CacheKey(Guid id) => $"order:{id}";
+
+    public async Task<Order?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var key = CacheKey(id);
+        var cached = await _cache.GetStringAsync(key, cancellationToken);
+        if (cached is not null)
+        {
+            return JsonSerializer.Deserialize<Order>(cached);
+        }
+
+        var order = await _dbContext.Orders
+            .AsNoTracking()
+            .Include(o => o.Items)
+            .FirstOrDefaultAsync(o => o.Id == id, cancellationToken);
+
+        if (order is not null)
+        {
+            await _cache.SetStringAsync(
+                key,
+                JsonSerializer.Serialize(order),
+                new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(10) },
+                cancellationToken);
+        }
+
+        return order;
+    }
+
+    public async Task<IReadOnlyList<Order>> ListAsync(string? status, int page, int pageSize, CancellationToken cancellationToken = default)
+    {
+        var key = $"orders:{status}:{page}:{pageSize}";
+        var cached = await _cache.GetStringAsync(key, cancellationToken);
+        if (cached is not null)
+        {
+            var list = JsonSerializer.Deserialize<List<Order>>(cached);
+            return list ?? new List<Order>();
+        }
+
+        var query = _dbContext.Orders.AsNoTracking().Include(o => o.Items).AsQueryable();
+        if (!string.IsNullOrEmpty(status))
+        {
+            query = query.Where(o => o.Status == status);
+        }
+
+        var orders = await query
+            .OrderBy(o => o.Id)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+
+        await _cache.SetStringAsync(
+            key,
+            JsonSerializer.Serialize(orders),
+            new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5) },
+            cancellationToken);
+
+        return orders;
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -2,7 +2,9 @@ var builder = WebApplication.CreateBuilder(args);
 
 using dotnet_microservices_boilerplate.OrderService.Domain.Brokers;
 using dotnet_microservices_boilerplate.OrderService.Infrastructure.Data;
+using dotnet_microservices_boilerplate.OrderService.Infrastructure.ViewData;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
 
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
@@ -19,6 +21,9 @@ var connectionString = builder.Configuration.GetConnectionString("Orders") ??
 builder.Services.AddDbContext<OrderDbContext>(options =>
     options.UseNpgsql(connectionString));
 builder.Services.AddScoped<OrderRepository>();
+builder.Services.AddStackExchangeRedisCache(options =>
+    options.Configuration = builder.Configuration.GetConnectionString("Redis") ?? "localhost:6379");
+builder.Services.AddScoped<OrderViewRepository>();
 
 var app = builder.Build();
 

--- a/README.md
+++ b/README.md
@@ -40,3 +40,4 @@ flowchart LR
     end
     Infrastructure -->|EF Core| PostgreSQL[(PostgreSQL)]
     ReadModel --> API
+\n### Caching Layer\nThe application now uses **Redis** for caching query results. A view database is accessed via EF Core to serve read models, and cached entries expire after a short period to keep data fresh.

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -6,7 +6,8 @@
     }
   },
   "ConnectionStrings": {
-    "Orders": "Host=localhost;Database=orders_db;Username=postgres;Password=postgres"
+    "Orders": "Host=localhost;Database=orders_db;Username=postgres;Password=postgres",
+    "Redis": "localhost:6379"
   },
   "Kafka": {
     "BootstrapServers": "localhost:9092"

--- a/appsettings.json
+++ b/appsettings.json
@@ -8,7 +8,8 @@
   "AllowedHosts": "*"
   ,
   "ConnectionStrings": {
-    "Orders": "Host=localhost;Database=orders_db;Username=postgres;Password=postgres"
+    "Orders": "Host=localhost;Database=orders_db;Username=postgres;Password=postgres",
+    "Redis": "localhost:6379"
   },
   "Kafka": {
     "BootstrapServers": "localhost:9092"

--- a/dotnet-microservices-boilerplate.csproj
+++ b/dotnet-microservices-boilerplate.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Confluent.Kafka" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- support Redis caching with view database repository
- wire up caching services in Program.cs
- add query handlers utilizing the cached repository
- document caching layer in README
- setup Redis connection strings in app settings

## Testing
- `dotnet restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ba5f52a248323a1122daecd512790