### PR TITLE
Add comprehensive unit tests

### DIFF
--- a/Domain/KafkaProducer.cs
+++ b/Domain/KafkaProducer.cs
@@ -2,7 +2,12 @@ using Confluent.Kafka;
 
 namespace dotnet_microservices_boilerplate.Domain;
 
-public class KafkaProducer
+public interface IKafkaProducer
+{
+    Task PublishAsync(string message);
+}
+
+public class KafkaProducer : IKafkaProducer
 {
     private readonly IProducer<Null, string> _producer;
     private readonly string _topic;

--- a/Domain/OrderService.cs
+++ b/Domain/OrderService.cs
@@ -5,9 +5,9 @@ namespace dotnet_microservices_boilerplate.Domain;
 public class OrderService
 {
     private readonly IOrderRepository _repository;
-    private readonly KafkaProducer _producer;
+    private readonly IKafkaProducer _producer;
 
-    public OrderService(IOrderRepository repository, KafkaProducer producer)
+    public OrderService(IOrderRepository repository, IKafkaProducer producer)
     {
         _repository = repository;
         _producer = producer;

--- a/OrderService/Application/Handlers/GetOrderByIdHandler.cs
+++ b/OrderService/Application/Handlers/GetOrderByIdHandler.cs
@@ -8,10 +8,10 @@ namespace dotnet_microservices_boilerplate.OrderService.Application.Handlers;
 
 public sealed class GetOrderByIdHandler : IRequestHandler<GetOrderByIdQuery, OrderDto>
 {
-    private readonly OrderViewRepository _repository;
+    private readonly IOrderViewRepository _repository;
     private readonly ILogger<GetOrderByIdHandler> _logger;
 
-    public GetOrderByIdHandler(OrderViewRepository repository, ILogger<GetOrderByIdHandler> logger)
+    public GetOrderByIdHandler(IOrderViewRepository repository, ILogger<GetOrderByIdHandler> logger)
     {
         _repository = repository;
         _logger = logger;

--- a/OrderService/Application/Handlers/ListOrdersHandler.cs
+++ b/OrderService/Application/Handlers/ListOrdersHandler.cs
@@ -8,10 +8,10 @@ namespace dotnet_microservices_boilerplate.OrderService.Application.Handlers;
 
 public sealed class ListOrdersHandler : IRequestHandler<ListOrdersQuery, PagedResult<OrderDto>>
 {
-    private readonly OrderViewRepository _repository;
+    private readonly IOrderViewRepository _repository;
     private readonly ILogger<ListOrdersHandler> _logger;
 
-    public ListOrdersHandler(OrderViewRepository repository, ILogger<ListOrdersHandler> logger)
+    public ListOrdersHandler(IOrderViewRepository repository, ILogger<ListOrdersHandler> logger)
     {
         _repository = repository;
         _logger = logger;

--- a/OrderService/Infrastructure/ViewData/OrderViewRepository.cs
+++ b/OrderService/Infrastructure/ViewData/OrderViewRepository.cs
@@ -6,7 +6,13 @@ using dotnet_microservices_boilerplate.OrderService.Infrastructure.Data;
 
 namespace dotnet_microservices_boilerplate.OrderService.Infrastructure.ViewData;
 
-public sealed class OrderViewRepository
+public interface IOrderViewRepository
+{
+    Task<Order?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<Order>> ListAsync(string? status, int page, int pageSize, CancellationToken cancellationToken = default);
+}
+
+public sealed class OrderViewRepository : IOrderViewRepository
 {
     private readonly OrderDbContext _dbContext;
     private readonly IDistributedCache _cache;

--- a/Program.cs
+++ b/Program.cs
@@ -37,7 +37,7 @@ builder.Services.AddDbContext<OrderDbContext>(options =>
 builder.Services.AddScoped<OrderRepository>();
 builder.Services.AddStackExchangeRedisCache(options =>
     options.Configuration = builder.Configuration.GetConnectionString("Redis") ?? "localhost:6379");
-builder.Services.AddScoped<OrderViewRepository>();
+builder.Services.AddScoped<IOrderViewRepository, OrderViewRepository>();
 
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracing =>

--- a/tests/Application/Behaviors/LoggingBehaviorTests.cs
+++ b/tests/Application/Behaviors/LoggingBehaviorTests.cs
@@ -1,0 +1,54 @@
+using System.Threading;
+using System.Threading.Tasks;
+using dotnet_microservices_boilerplate.OrderService.Application.Behaviors;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+public class LoggingBehaviorTests
+{
+    [Fact]
+    public async Task Handle_Should_Log_And_Return_Response()
+    {
+        var logger = Substitute.For<ILogger<LoggingBehavior<string, int>>>();
+        var behavior = new LoggingBehavior<string, int>(logger);
+        var next = Substitute.For<RequestHandlerDelegate<int>>();
+        next.Invoke().Returns(42);
+
+        var result = await behavior.Handle("req", next, CancellationToken.None);
+
+        result.Should().Be(42);
+        logger.Received().Log(
+            LogLevel.Information,
+            Arg.Any<EventId>(),
+            Arg.Any<object?>(),
+            null,
+            Arg.Any<Func<object, Exception?, string>>());
+        logger.Received().Log(
+            LogLevel.Information,
+            Arg.Any<EventId>(),
+            Arg.Any<object?>(),
+            null,
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task Handle_Should_Log_Error_On_Exception()
+    {
+        var logger = Substitute.For<ILogger<LoggingBehavior<string, int>>>();
+        var behavior = new LoggingBehavior<string, int>(logger);
+        var next = Substitute.For<RequestHandlerDelegate<int>>();
+        next.Invoke().Returns<int>(x => { throw new InvalidOperationException(); });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => behavior.Handle("req", next, CancellationToken.None));
+
+        logger.Received().Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Any<object?>(),
+            Arg.Any<Exception>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+}

--- a/tests/Application/Handlers/CreateOrderHandlerTests.cs
+++ b/tests/Application/Handlers/CreateOrderHandlerTests.cs
@@ -1,0 +1,25 @@
+using dotnet_microservices_boilerplate.OrderService.Application.Commands;
+using dotnet_microservices_boilerplate.OrderService.Application.Handlers;
+using dotnet_microservices_boilerplate.OrderService.Domain.Brokers;
+using dotnet_microservices_boilerplate.OrderService.Domain.Events;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+public class CreateOrderHandlerTests
+{
+    [Fact]
+    public async Task Handle_Should_Produce_Event_And_Return_Id()
+    {
+        var broker = Substitute.For<IKafkaBroker>();
+        var logger = Substitute.For<ILogger<CreateOrderHandler>>();
+        var handler = new CreateOrderHandler(broker, logger);
+        var cmd = new CreateOrderCommand(new[] { new CreateOrderItemDto("p", 1, 2m) });
+
+        var id = await handler.Handle(cmd, CancellationToken.None);
+
+        id.Should().NotBeEmpty();
+        await broker.Received().ProduceAsync("orders", Arg.Any<OrderCreatedEvent>(), CancellationToken.None);
+    }
+}

--- a/tests/Application/Handlers/GetOrderByIdHandlerTests.cs
+++ b/tests/Application/Handlers/GetOrderByIdHandlerTests.cs
@@ -1,0 +1,39 @@
+using dotnet_microservices_boilerplate.OrderService.Application.Dtos;
+using dotnet_microservices_boilerplate.OrderService.Application.Handlers;
+using dotnet_microservices_boilerplate.OrderService.Application.Queries;
+using dotnet_microservices_boilerplate.OrderService.Domain.Entities;
+using dotnet_microservices_boilerplate.OrderService.Infrastructure.ViewData;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+public class GetOrderByIdHandlerTests
+{
+    [Fact]
+    public async Task Handle_Should_Return_Dto_When_Order_Found()
+    {
+        var repo = Substitute.For<IOrderViewRepository>();
+        var logger = Substitute.For<ILogger<GetOrderByIdHandler>>();
+        var handler = new GetOrderByIdHandler(repo, logger);
+        var order = new Order { Id = Guid.NewGuid(), Status = "Pending" };
+        order.Items.Add(new OrderItem { ProductName = "p", Quantity = 1, UnitPrice = 2m });
+        repo.GetByIdAsync(order.Id, CancellationToken.None).Returns(order);
+
+        var dto = await handler.Handle(new GetOrderByIdQuery(order.Id), CancellationToken.None);
+
+        dto.Id.Should().Be(order.Id);
+        dto.Items.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Handle_Should_Throw_When_Not_Found()
+    {
+        var repo = Substitute.For<IOrderViewRepository>();
+        var logger = Substitute.For<ILogger<GetOrderByIdHandler>>();
+        var handler = new GetOrderByIdHandler(repo, logger);
+        repo.GetByIdAsync(Arg.Any<Guid>(), CancellationToken.None).Returns((Order?)null);
+
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => handler.Handle(new GetOrderByIdQuery(Guid.NewGuid()), CancellationToken.None));
+    }
+}

--- a/tests/Application/Handlers/ListOrdersHandlerTests.cs
+++ b/tests/Application/Handlers/ListOrdersHandlerTests.cs
@@ -1,0 +1,28 @@
+using dotnet_microservices_boilerplate.OrderService.Application.Dtos;
+using dotnet_microservices_boilerplate.OrderService.Application.Handlers;
+using dotnet_microservices_boilerplate.OrderService.Application.Queries;
+using dotnet_microservices_boilerplate.OrderService.Domain.Entities;
+using dotnet_microservices_boilerplate.OrderService.Infrastructure.ViewData;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+public class ListOrdersHandlerTests
+{
+    [Fact]
+    public async Task Handle_Should_Return_PagedResult()
+    {
+        var repo = Substitute.For<IOrderViewRepository>();
+        var logger = Substitute.For<ILogger<ListOrdersHandler>>();
+        var handler = new ListOrdersHandler(repo, logger);
+        var orders = new List<Order> { new Order { Id = Guid.NewGuid() } };
+        repo.ListAsync(null, 1, 20, CancellationToken.None).Returns(orders);
+
+        var result = await handler.Handle(new ListOrdersQuery(null), CancellationToken.None);
+
+        result.Items.Should().HaveCount(1);
+        result.Page.Should().Be(1);
+        result.TotalCount.Should().Be(1);
+    }
+}

--- a/tests/Domain/OrderServiceTests.cs
+++ b/tests/Domain/OrderServiceTests.cs
@@ -1,0 +1,38 @@
+using System.Threading.Tasks;
+using dotnet_microservices_boilerplate.Domain;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+public class OrderServiceTests
+{
+    [Fact]
+    public async Task CreateOrderAsync_Should_Save_And_Publish()
+    {
+        var repo = Substitute.For<IOrderRepository>();
+        var producer = Substitute.For<IKafkaProducer>();
+        var service = new OrderService(repo, producer);
+        var order = new Order { Id = Guid.NewGuid(), CreatedAt = DateTime.UtcNow };
+
+        await service.CreateOrderAsync(order);
+
+        await repo.Received().SaveAsync(order);
+        await producer.Received().PublishAsync(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task GetOrderAsync_Should_Return_Order_And_Publish()
+    {
+        var repo = Substitute.For<IOrderRepository>();
+        var producer = Substitute.For<IKafkaProducer>();
+        var service = new OrderService(repo, producer);
+        var order = new Order { Id = Guid.NewGuid(), CreatedAt = DateTime.UtcNow };
+        repo.GetAsync(order.Id).Returns(order);
+
+        var result = await service.GetOrderAsync(order.Id);
+
+        result.Should().Be(order);
+        await repo.Received().GetAsync(order.Id);
+        await producer.Received().PublishAsync(Arg.Any<string>());
+    }
+}

--- a/tests/Infrastructure/Data/OrderRepositoryTests.cs
+++ b/tests/Infrastructure/Data/OrderRepositoryTests.cs
@@ -1,0 +1,48 @@
+using dotnet_microservices_boilerplate.OrderService.Domain.Entities;
+using dotnet_microservices_boilerplate.OrderService.Infrastructure.Data;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+public class OrderRepositoryTests
+{
+    private static OrderDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<OrderDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new OrderDbContext(options);
+    }
+
+    [Fact]
+    public async Task SaveAsync_Should_Add_New_Order()
+    {
+        var context = CreateContext();
+        var logger = Substitute.For<ILogger<OrderRepository>>();
+        var repo = new OrderRepository(context, logger);
+        var order = new Order { Id = Guid.NewGuid() };
+
+        await repo.SaveAsync(order);
+
+        var saved = await context.Orders.FirstOrDefaultAsync(o => o.Id == order.Id);
+        saved.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetAsync_Should_Return_Order()
+    {
+        var context = CreateContext();
+        var logger = Substitute.For<ILogger<OrderRepository>>();
+        var repo = new OrderRepository(context, logger);
+        var order = new Order { Id = Guid.NewGuid() };
+        context.Orders.Add(order);
+        await context.SaveChangesAsync();
+
+        var result = await repo.GetAsync(order.Id);
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(order.Id);
+    }
+}

--- a/tests/Infrastructure/Middleware/ErrorHandlingMiddlewareTests.cs
+++ b/tests/Infrastructure/Middleware/ErrorHandlingMiddlewareTests.cs
@@ -1,0 +1,59 @@
+using System.Net;
+using System.Text.Json;
+using dotnet_microservices_boilerplate.OrderService.Infrastructure.Middleware;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+public class ErrorHandlingMiddlewareTests
+{
+    [Fact]
+    public async Task Invoke_Should_Return_NotFound_For_KeyNotFoundException()
+    {
+        var logger = Substitute.For<ILogger<ErrorHandlingMiddleware>>();
+        var middleware = new ErrorHandlingMiddleware(ctx => throw new KeyNotFoundException("missing"), logger);
+        var context = new DefaultHttpContext();
+        var stream = new MemoryStream();
+        context.Response.Body = stream;
+
+        await middleware.InvokeAsync(context);
+
+        context.Response.StatusCode.Should().Be((int)HttpStatusCode.NotFound);
+        stream.Position = 0;
+        var body = await JsonDocument.ParseAsync(stream);
+        body.RootElement.GetProperty("error").GetString().Should().Be("missing");
+    }
+
+    [Fact]
+    public async Task Invoke_Should_Return_InternalServerError_For_Exception()
+    {
+        var logger = Substitute.For<ILogger<ErrorHandlingMiddleware>>();
+        var middleware = new ErrorHandlingMiddleware(ctx => throw new InvalidOperationException(), logger);
+        var context = new DefaultHttpContext();
+        var stream = new MemoryStream();
+        context.Response.Body = stream;
+
+        await middleware.InvokeAsync(context);
+
+        context.Response.StatusCode.Should().Be((int)HttpStatusCode.InternalServerError);
+        stream.Position = 0;
+        var body = await JsonDocument.ParseAsync(stream);
+        body.RootElement.GetProperty("error").GetString().Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Invoke_Should_Pass_Through_When_No_Exception()
+    {
+        var logger = Substitute.For<ILogger<ErrorHandlingMiddleware>>();
+        var called = false;
+        var middleware = new ErrorHandlingMiddleware(ctx => { called = true; return Task.CompletedTask; }, logger);
+        var context = new DefaultHttpContext();
+
+        await middleware.InvokeAsync(context);
+
+        called.Should().BeTrue();
+        context.Response.StatusCode.Should().Be((int)HttpStatusCode.OK);
+    }
+}

--- a/tests/Infrastructure/ViewData/OrderViewRepositoryTests.cs
+++ b/tests/Infrastructure/ViewData/OrderViewRepositoryTests.cs
@@ -1,0 +1,53 @@
+using dotnet_microservices_boilerplate.OrderService.Domain.Entities;
+using dotnet_microservices_boilerplate.OrderService.Infrastructure.Data;
+using dotnet_microservices_boilerplate.OrderService.Infrastructure.ViewData;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+public class OrderViewRepositoryTests
+{
+    private static OrderDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<OrderDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new OrderDbContext(options);
+    }
+
+    private static IDistributedCache CreateCache() => new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+
+    [Fact]
+    public async Task GetByIdAsync_Should_Return_From_Cache()
+    {
+        var context = CreateContext();
+        var cache = CreateCache();
+        var repo = new OrderViewRepository(context, cache);
+        var order = new Order { Id = Guid.NewGuid() };
+        context.Orders.Add(order);
+        await context.SaveChangesAsync();
+
+        var first = await repo.GetByIdAsync(order.Id);
+        var second = await repo.GetByIdAsync(order.Id);
+
+        first.Should().NotBeNull();
+        second.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ListAsync_Should_Return_Orders()
+    {
+        var context = CreateContext();
+        var cache = CreateCache();
+        var repo = new OrderViewRepository(context, cache);
+        context.Orders.Add(new Order { Id = Guid.NewGuid() });
+        await context.SaveChangesAsync();
+
+        var result = await repo.ListAsync(null, 1, 10);
+
+        result.Should().HaveCount(1);
+    }
+}

--- a/tests/dotnet-microservices-boilerplate.Tests.csproj
+++ b/tests/dotnet-microservices-boilerplate.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\dotnet-microservices-boilerplate.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add IKafkaProducer and use it in OrderService
- introduce IOrderViewRepository for easier mocking
- update program and handlers to use new interfaces
- add xUnit test project with FluentAssertions and NSubstitute
- cover behaviors, handlers, repositories, middleware, and service

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb937a83c8323b5218d7362cb6d18