### PR TITLE
Replace xUnit with NUnit

### DIFF
--- a/tests/Application/Behaviors/LoggingBehaviorTests.cs
+++ b/tests/Application/Behaviors/LoggingBehaviorTests.cs
@@ -5,12 +5,12 @@ using FluentAssertions;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
-using Xunit;
+using NUnit.Framework;
 using System;
 
 public class LoggingBehaviorTests
 {
-    [Fact]
+    [Test]
     public async Task Handle_Should_Log_And_Return_Response()
     {
         var logger = Substitute.For<ILogger<LoggingBehavior<string, int>>>();
@@ -35,7 +35,7 @@ public class LoggingBehaviorTests
             Arg.Any<Func<object, Exception?, string>>());
     }
 
-    [Fact]
+    [Test]
     public async Task Handle_Should_Log_Error_On_Exception()
     {
         var logger = Substitute.For<ILogger<LoggingBehavior<string, int>>>();
@@ -43,7 +43,7 @@ public class LoggingBehaviorTests
         var next = Substitute.For<RequestHandlerDelegate<int>>();
         next.Invoke().Returns<int>(x => { throw new InvalidOperationException(); });
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => behavior.Handle("req", next, CancellationToken.None));
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await behavior.Handle("req", next, CancellationToken.None));
 
         logger.Received().Log(
             LogLevel.Error,

--- a/tests/Application/Handlers/CreateOrderHandlerTests.cs
+++ b/tests/Application/Handlers/CreateOrderHandlerTests.cs
@@ -5,13 +5,13 @@ using PWorx.MicroserviceBoilerPlate.OrderService.Domain.Events;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
-using Xunit;
+using NUnit.Framework;
 using System.Threading.Tasks;
 using System.Threading;
 
 public class CreateOrderHandlerTests
 {
-    [Fact]
+    [Test]
     public async Task Handle_Should_Produce_Event_And_Return_Id()
     {
         var broker = Substitute.For<IKafkaBroker>();

--- a/tests/Application/Handlers/GetOrderByIdHandlerTests.cs
+++ b/tests/Application/Handlers/GetOrderByIdHandlerTests.cs
@@ -5,7 +5,7 @@ using PWorx.MicroserviceBoilerPlate.OrderService.Infrastructure.ViewData;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
-using Xunit;
+using NUnit.Framework;
 using System.Threading.Tasks;
 using System;
 using System.Threading;
@@ -13,7 +13,7 @@ using System.Collections.Generic;
 
 public class GetOrderByIdHandlerTests
 {
-    [Fact]
+    [Test]
     public async Task Handle_Should_Return_Dto_When_Order_Found()
     {
         var repo = Substitute.For<IOrderViewRepository>();
@@ -29,7 +29,7 @@ public class GetOrderByIdHandlerTests
         dto.Items.Should().HaveCount(1);
     }
 
-    [Fact]
+    [Test]
     public async Task Handle_Should_Throw_When_Not_Found()
     {
         var repo = Substitute.For<IOrderViewRepository>();
@@ -37,6 +37,6 @@ public class GetOrderByIdHandlerTests
         var handler = new GetOrderByIdHandler(repo, logger);
         repo.GetByIdAsync(Arg.Any<Guid>(), CancellationToken.None).Returns((Order?)null);
 
-        await Assert.ThrowsAsync<KeyNotFoundException>(() => handler.Handle(new GetOrderByIdQuery(Guid.NewGuid()), CancellationToken.None));
+        Assert.ThrowsAsync<KeyNotFoundException>(async () => await handler.Handle(new GetOrderByIdQuery(Guid.NewGuid()), CancellationToken.None));
     }
 }

--- a/tests/Application/Handlers/ListOrdersHandlerTests.cs
+++ b/tests/Application/Handlers/ListOrdersHandlerTests.cs
@@ -6,7 +6,7 @@ using PWorx.MicroserviceBoilerPlate.OrderService.Infrastructure.ViewData;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
-using Xunit;
+using NUnit.Framework;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Threading;
@@ -14,7 +14,7 @@ using System;
 
 public class ListOrdersHandlerTests
 {
-    [Fact]
+    [Test]
     public async Task Handle_Should_Return_PagedResult()
     {
         var repo = Substitute.For<IOrderViewRepository>();

--- a/tests/Domain/OrderServiceTests.cs
+++ b/tests/Domain/OrderServiceTests.cs
@@ -2,12 +2,12 @@ using System.Threading.Tasks;
 using PWorx.MicroserviceBoilerPlate.Domain;
 using FluentAssertions;
 using NSubstitute;
-using Xunit;
+using NUnit.Framework;
 using System;
 
 public class OrderServiceTests
 {
-    [Fact]
+    [Test]
     public async Task CreateOrderAsync_Should_Save_And_Publish()
     {
         var repo = Substitute.For<IOrderRepository>();
@@ -21,7 +21,7 @@ public class OrderServiceTests
         await producer.Received().PublishAsync(Arg.Any<string>());
     }
 
-    [Fact]
+    [Test]
     public async Task GetOrderAsync_Should_Return_Order_And_Publish()
     {
         var repo = Substitute.For<IOrderRepository>();

--- a/tests/Infrastructure/Data/OrderRepositoryTests.cs
+++ b/tests/Infrastructure/Data/OrderRepositoryTests.cs
@@ -4,7 +4,7 @@ using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
-using Xunit;
+using NUnit.Framework;
 using System;
 using System.Threading.Tasks;
 
@@ -18,7 +18,7 @@ public class OrderRepositoryTests
         return new OrderDbContext(options);
     }
 
-    [Fact]
+    [Test]
     public async Task SaveAsync_Should_Add_New_Order()
     {
         var context = CreateContext();
@@ -32,7 +32,7 @@ public class OrderRepositoryTests
         saved.Should().NotBeNull();
     }
 
-    [Fact]
+    [Test]
     public async Task GetAsync_Should_Return_Order()
     {
         var context = CreateContext();

--- a/tests/Infrastructure/Middleware/ErrorHandlingMiddlewareTests.cs
+++ b/tests/Infrastructure/Middleware/ErrorHandlingMiddlewareTests.cs
@@ -5,7 +5,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
-using Xunit;
+using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -13,7 +13,7 @@ using System;
 
 public class ErrorHandlingMiddlewareTests
 {
-    [Fact]
+    [Test]
     public async System.Threading.Tasks.Task Invoke_Should_Return_NotFound_For_KeyNotFoundException()
     {
         var logger = Substitute.For<ILogger<ErrorHandlingMiddleware>>();
@@ -30,7 +30,7 @@ public class ErrorHandlingMiddlewareTests
         body.RootElement.GetProperty("error").GetString().Should().Be("missing");
     }
 
-    [Fact]
+    [Test]
     public async Task Invoke_Should_Return_InternalServerError_For_Exception()
     {
         var logger = Substitute.For<ILogger<ErrorHandlingMiddleware>>();
@@ -47,7 +47,7 @@ public class ErrorHandlingMiddlewareTests
         body.RootElement.GetProperty("error").GetString().Should().NotBeNull();
     }
 
-    [Fact]
+    [Test]
     public async Task Invoke_Should_Pass_Through_When_No_Exception()
     {
         var logger = Substitute.For<ILogger<ErrorHandlingMiddleware>>();

--- a/tests/Infrastructure/ViewData/OrderViewRepositoryTests.cs
+++ b/tests/Infrastructure/ViewData/OrderViewRepositoryTests.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
-using Xunit;
+using NUnit.Framework;
 using System;
 using System.Threading.Tasks;
 
@@ -22,7 +22,7 @@ public class OrderViewRepositoryTests
 
     private static IDistributedCache CreateCache() => new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
 
-    [Fact]
+    [Test]
     public async Task GetByIdAsync_Should_Return_From_Cache()
     {
         var context = CreateContext();
@@ -39,7 +39,7 @@ public class OrderViewRepositoryTests
         second.Should().NotBeNull();
     }
 
-    [Fact]
+    [Test]
     public async Task ListAsync_Should_Return_Orders()
     {
         var context = CreateContext();

--- a/tests/dotnet-microservices-boilerplate.Tests.csproj
+++ b/tests/dotnet-microservices-boilerplate.Tests.csproj
@@ -7,8 +7,9 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="NSubstitute" Version="5.0.0" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- switch test framework from xUnit to NUnit
- update test project references
- adjust attributes and asserts for NUnit

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bf34b37cc83239d6ba4d2abae336a